### PR TITLE
Fixing TwoLevelQueue Initialization

### DIFF
--- a/include/Core/Queue/TwoLevelQueue.cuh
+++ b/include/Core/Queue/TwoLevelQueue.cuh
@@ -191,6 +191,11 @@ private:
     mutable int2 _h_counters          { 0, 0 };
     bool         _kernel_copy         { false };
     int          _enqueue_items       { 0 };
+
+    /**
+     * @brief Internal function to initialize max allocated items
+     */
+    void _initialize() noexcept;
 };
 
 } // namespace hornets_nest

--- a/include/Core/Queue/TwoLevelQueue.i.cuh
+++ b/include/Core/Queue/TwoLevelQueue.i.cuh
@@ -54,10 +54,13 @@ TwoLevelQueue<T>::TwoLevelQueue(const HornetClass& hornet,
                               _max_allocated_items(hornet.nV() * work_factor) {
     static_assert(IsHornet<HornetClass>::value,
                  "TwoLevelQueue paramenter is not an instance of Hornet Class");
-    cuMalloc(_d_queue_ptrs.first, _max_allocated_items);
-    cuMalloc(_d_queue_ptrs.second, _max_allocated_items);
-    cuMalloc(_d_counters, 1);
-    cuMemset0x00(_d_counters);
+    _initialize();
+}
+
+template<typename T>
+TwoLevelQueue<T>::TwoLevelQueue(size_t max_allocated_items) noexcept :
+                        _max_allocated_items(max_allocated_items) {
+    _initialize();
 }
 
 template<typename T>
@@ -77,9 +80,21 @@ TwoLevelQueue<T>::~TwoLevelQueue() noexcept {
 template<typename T>
 template<typename HornetClass>
 void TwoLevelQueue<T>::initialize(const HornetClass& hornet,
-                                 const float work_factors) noexcept {
+                                 const float work_factor) noexcept {
+    _max_allocated_items = hornet.nV() * work_factor;
     static_assert(IsHornet<HornetClass>::value,
                  "TwoLevelQueue paramenter is not an instance of Hornet Class");
+    _initialize();
+}
+
+template<typename T>
+void TwoLevelQueue<T>::initialize(size_t max_allocated_items) noexcept {
+    _max_allocated_items = max_allocated_items;
+    _initialize();
+}
+
+template<typename T>
+void TwoLevelQueue<T>::_initialize() noexcept {
     cuMalloc(_d_queue_ptrs.first, _max_allocated_items);
     cuMalloc(_d_queue_ptrs.second, _max_allocated_items);
     cuMalloc(_d_counters, 1);


### PR DESCRIPTION
Adding a private initialization method, implementing the constructor with (max_allocated_items), and fixing the initialization method with hornet.

We tested this in TriangleCounting with manually initialized queues both with hornet and a work factor as well as with max allocated items.