### PR TITLE
Modified testers

### DIFF
--- a/src/Static/ConnectedComponents/CC.cu
+++ b/src/Static/ConnectedComponents/CC.cu
@@ -88,8 +88,7 @@ struct ColoringOperator {
         bool continue_var;
         auto src_color = d_colors[vertex_pair.x];
         auto dst_color = d_colors[vertex_pair.y];
-        //printf("%d\t->\t%d:\t%d\t%d\n",
-        //        vertex_pair.x, vertex_pair.y, src_color, dst_color);
+
         if (src_color > dst_color) {
             d_colors[vertex_pair.y] = d_colors[vertex_pair.x];
             continue_var = true;
@@ -103,24 +102,9 @@ struct ColoringOperator {
 
         if (continue_var)
             d_continue = true;
-        //gpu::reduce_or(d_continue.ptr(), continue_var);
+
     }
 };
-
-/*
-struct ColorigAtomic {
-    EnqueueOperator(color_t* d_colors_, TwoLevelQueue<int2> queue_) :
-                                Common(d_colors_, queue_) {}
-
-    __device__ __forceinline__
-    bool operator()(const int2& item) {
-        auto src_color = d_colors[item.x];
-        auto old_color = atomicMax(d_colors + item.y, src_color);
-        if (src_color < old_color)
-            atomicMax(d_colors + item.x, old_color);
-        //d_colors[item.x] = old_color;
-    }
-};*/
 
 //------------------------------------------------------------------------------
 ////////
@@ -199,8 +183,7 @@ bool CC::validate() {
 
     bool ret = true;
     for (vid_t i = 0; i < graph.nV(); i++) {
-//        std::cout << i << "\t"
-//                  << h_results[i] << "\t" << d_results[i] << std::endl;
+
         if (color_match1[ h_results[i] ] == NO_COLOR &&
                 color_match2[ d_results[i] ] == NO_COLOR) {
             color_match2[ d_results[i] ] = h_results[i];

--- a/src/Static/ConnectedComponents/CC.cu
+++ b/src/Static/ConnectedComponents/CC.cu
@@ -199,8 +199,8 @@ bool CC::validate() {
 
     bool ret = true;
     for (vid_t i = 0; i < graph.nV(); i++) {
-        std::cout << i << "\t"
-                  << h_results[i] << "\t" << d_results[i] << std::endl;
+//        std::cout << i << "\t"
+//                  << h_results[i] << "\t" << d_results[i] << std::endl;
         if (color_match1[ h_results[i] ] == NO_COLOR &&
                 color_match2[ d_results[i] ] == NO_COLOR) {
             color_match2[ d_results[i] ] = h_results[i];

--- a/test/BFSTest.cu
+++ b/test/BFSTest.cu
@@ -13,20 +13,19 @@ int main(int argc, char* argv[]) {
 
     graph::GraphStd<vid_t, eoff_t> graph;
     CommandLineParam cmd(graph, argc, argv,false);
-    //graph.print();
+
 
     HornetInit hornet_init(graph.nV(), graph.nE(), graph.csr_out_offsets(),
                            graph.csr_out_edges());
 
     HornetGraph hornet_graph(hornet_init);
-    //hornet_graph.print();
 
     BfsTopDown bfs_top_down(hornet_graph);
 
 	vid_t root = graph.max_out_degree_id();
 	if (argc==3)
 	  root = atoi(argv[2]);
-    //bfs_top_down.set_parameters(graph.max_out_degree_id());
+
     bfs_top_down.set_parameters(root);
 
     Timer<DEVICE> TM;

--- a/test/BFSTest.cu
+++ b/test/BFSTest.cu
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
     using namespace hornets_nest;
 
     graph::GraphStd<vid_t, eoff_t> graph;
-    CommandLineParam cmd(graph, argc, argv);
+    CommandLineParam cmd(graph, argc, argv,false);
     //graph.print();
 
     HornetInit hornet_init(graph.nV(), graph.nE(), graph.csr_out_offsets(),
@@ -23,7 +23,11 @@ int main(int argc, char* argv[]) {
 
     BfsTopDown bfs_top_down(hornet_graph);
 
-    bfs_top_down.set_parameters(graph.max_out_degree_id());
+	vid_t root = graph.max_out_degree_id();
+	if (argc==3)
+	  root = atoi(argv[2]);
+    //bfs_top_down.set_parameters(graph.max_out_degree_id());
+    bfs_top_down.set_parameters(root);
 
     Timer<DEVICE> TM;
     cudaProfilerStart();

--- a/test/BFSTest2.cu
+++ b/test/BFSTest2.cu
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
     using namespace hornets_nest;
 
     graph::GraphStd<vid_t, eoff_t> graph;
-    CommandLineParam cmd(graph, argc, argv);
+    CommandLineParam cmd(graph, argc, argv,false);
     //graph.print();
 
     HornetInit hornet_init(graph.nV(), graph.nE(), graph.csr_out_offsets(),
@@ -22,9 +22,13 @@ int main(int argc, char* argv[]) {
     //hornet_graph.print();
 
     BfsTopDown2 bfs_top_down(hornet_graph);
-
-    bfs_top_down.set_parameters(graph.max_out_degree_id());
-
+ 
+	vid_t root = graph.max_out_degree_id();
+	if (argc==3)
+	  root = atoi(argv[2]);
+    //bfs_top_down.set_parameters(graph.max_out_degree_id());
+    bfs_top_down.set_parameters(root);
+ 
     Timer<DEVICE> TM;
     cudaProfilerStart();
     TM.start();

--- a/test/BFSTest2.cu
+++ b/test/BFSTest2.cu
@@ -13,20 +13,20 @@ int main(int argc, char* argv[]) {
 
     graph::GraphStd<vid_t, eoff_t> graph;
     CommandLineParam cmd(graph, argc, argv,false);
-    //graph.print();
+
 
     HornetInit hornet_init(graph.nV(), graph.nE(), graph.csr_out_offsets(),
                            graph.csr_out_edges());
 
     HornetGraph hornet_graph(hornet_init);
-    //hornet_graph.print();
+
 
     BfsTopDown2 bfs_top_down(hornet_graph);
  
 	vid_t root = graph.max_out_degree_id();
 	if (argc==3)
 	  root = atoi(argv[2]);
-    //bfs_top_down.set_parameters(graph.max_out_degree_id());
+
     bfs_top_down.set_parameters(root);
  
     Timer<DEVICE> TM;

--- a/test/SSSPTest.cu
+++ b/test/SSSPTest.cu
@@ -23,9 +23,9 @@ int main(int argc, char* argv[]) {
 
     HornetGraph hornet_graph(hornet_init);
 
-	vid_t root = 0;
-	if(argc==3) 
-	  root = atoi(argv[2]);
+    vid_t root = 0;
+    if(argc==3) 
+        root = atoi(argv[2]);
 
     SSSP sssp(hornet_graph);
     sssp.set_parameters(root);

--- a/test/SSSPTest.cu
+++ b/test/SSSPTest.cu
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
     using namespace hornets_nest;
 
     graph::GraphStd<vid_t, eoff_t> graph;
-    CommandLineParam cmd(graph, argc, argv);
+    CommandLineParam cmd(graph, argc, argv,false);
 
     auto h_weights = new weight_t[graph.nE()];
     host::generate_randoms(h_weights, graph.nE(), 0, 100);
@@ -30,8 +30,12 @@ int main(int argc, char* argv[]) {
     HornetGraph hornet_graph(hornet_init);
     // hornet_graph.print();                // <--- GRAPH PRINT
 
+	vid_t root = 0;
+	if(argc==3) 
+	  root = atoi(argv[2]);
+
     SSSP sssp(hornet_graph);
-    sssp.set_parameters(0);
+    sssp.set_parameters(root);
 
     Timer<DEVICE> TM;
     TM.start();

--- a/test/SSSPTest.cu
+++ b/test/SSSPTest.cu
@@ -21,14 +21,7 @@ int main(int argc, char* argv[]) {
                            graph.csr_out_edges());
     hornet_init.insertEdgeData(h_weights);
 
-    /*graph::GraphWeight<vid_t, eoff_t, int> graph;
-    graph.read(argv[1]);
-    HornetInit hornet_init(graph.nV(), graph.nE(), graph.csr_out_offsets(),
-                           graph.csr_out_edges());
-    hornet_init.insertEdgeData(graph.out_weights_array());*/
-
     HornetGraph hornet_graph(hornet_init);
-    // hornet_graph.print();                // <--- GRAPH PRINT
 
 	vid_t root = 0;
 	if(argc==3) 


### PR DESCRIPTION
Connected components validation function was printing out by default all connected component id.
SSSP and BFS now allow users to select the root from command line. Default root will continue to be the maximal vertex.