### PR TITLE
fixed CMakeLists to include all sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ include_directories(externals/hornet/externals/xlib/include)
 
 include(externals/hornet/externals/xlib/util/CMakeLists.txt)
 #-------------------------------------------------------------------------------
-file(GLOB_RECURSE CU_SRCS ${PROJECT_SOURCE_DIR}/src/*triangle*.cu)
-file(GLOB_RECURSE CPP_SRCS ${PROJECT_SOURCE_DIR}/externals/xlib/src/*triangle*.cu)
+file(GLOB_RECURSE CU_SRCS ${PROJECT_SOURCE_DIR}/src/*)
+file(GLOB_RECURSE CPP_SRCS ${PROJECT_SOURCE_DIR}/externals/xlib/src/*)
 
 cuda_add_library(hornetAlg ${CU_SRCS})
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
CMakeLists.txt filtered out most of the sources, such that targets cannot be compiled. This change adds back in all the sources so that all applications in tests are compiled.